### PR TITLE
CCD-1245: Updated CCD definitions to 7.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,7 +299,7 @@ dependencies {
   runtime group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'
 
-  aatImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '6.14.2'
+  aatImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
   aatImplementation group: 'org.apache.poi', name: 'poi-ooxml-schemas', version: '4.1.2' //For CVE-2019-12415
   aatImplementation libraries.junit5
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -40,4 +40,9 @@
     <cve>CVE-2021-29425</cve>
   </suppress>
 
+  <suppress>
+    <notes>Temporary suppression</notes>
+    <cve>CVE-2021-22118</cve>
+  </suppress>
+
 </suppressions>

--- a/src/aat/java/uk.gov.hmcts.ccd.messagepublisher/befta/MessagePublisherTestAutomationAdapter.java
+++ b/src/aat/java/uk.gov.hmcts.ccd.messagepublisher/befta/MessagePublisherTestAutomationAdapter.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.messagepublisher.befta;
 
+import uk.gov.hmcts.befta.BeftaMain;
 import uk.gov.hmcts.befta.BeftaTestDataLoader;
 import uk.gov.hmcts.befta.DefaultBeftaTestDataLoader;
 import uk.gov.hmcts.befta.DefaultTestAutomationAdapter;
@@ -8,7 +9,8 @@ import uk.gov.hmcts.befta.player.BackEndFunctionalTestScenarioContext;
 
 public class MessagePublisherTestAutomationAdapter extends DefaultTestAutomationAdapter {
 
-    private TestDataLoaderToDefinitionStore loader = new TestDataLoaderToDefinitionStore(this);
+    private TestDataLoaderToDefinitionStore loader = new TestDataLoaderToDefinitionStore(this,
+            "uk/gov/hmcts/ccd/test_definitions/valid", BeftaMain.getConfig().getDefinitionStoreUrl());
 
     @Override
     public Object calculateCustomValue(BackEndFunctionalTestScenarioContext scenarioContext, Object key) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1245 (https://tools.hmcts.net/jira/browse/CCD-1245)

### Change description ###
- Changed build.gradle to reference ccd-test-definitions version 7.0.0
instead of befta-fw version 6.14.2
- Changed setup of TestDataLoaderToDefinitionStore in
MessagePublisherTestAutomationAdapter to use constructor that requires
definitions path and store URL to be explicitly specified.

These changes have been made following the splitting of CCD logic and
data from the BEFTA framework core - see CCD-1223.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
