### PR TITLE
CCD-1330: Updated CVE suppression dates to 25/08/2021

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2021-07-25">
+  <suppress until="2021-08-25">
     <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
       (any version), see https://pivotal.io/security/cve-2018-1258
       False positive confirmed.
+      Last control version: 5.5.1
     </notes>
     <cve>CVE-2018-1258</cve>
   </suppress>
 
-  <suppress until="2021-07-25">
+  <suppress until="2021-08-25">
    <notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
       library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
+     Last control version: 1.5
     </notes>
     <cve>CVE-2020-29242</cve>
     <cve>CVE-2020-29243</cve>
@@ -17,10 +19,11 @@
     <cve>CVE-2020-29245</cve>
   </suppress>
 
-  <suppress until="2021-07-25">
+  <suppress until="2021-08-25">
     <notes>
       <![CDATA[
         Required dependencies with no current fixes
+        Last control version: 5.16.2
     ]]>
     </notes>
     <cve>CVE-2015-5182</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1330 (https://tools.hmcts.net/jira/browse/CCD-1330)
https://tools.hmcts.net/jira/browse/CCD-1684
https://tools.hmcts.net/jira/browse/CCD-1685
https://tools.hmcts.net/jira/browse/CCD-1686
https://tools.hmcts.net/jira/browse/CCD-1687
https://tools.hmcts.net/jira/browse/CCD-1688
https://tools.hmcts.net/jira/browse/CCD-1689

### Change description ###
Updated CVE suppression dates to 25/08/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
