### PR TITLE
Updated CVE suppression dates in suppressions.xml to 25/10/2021

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  
+
   <suppress>
     <notes>
-			Declared as False positive on library com.nimbusds:lang-tag #3594 
+			Declared as False positive on library com.nimbusds:lang-tag #3594
 			https://github.com/jeremylong/DependencyCheck/issues/3594
 			CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1872
     </notes>
@@ -11,7 +11,7 @@
     <cve>CVE-2020-23171</cve>
 	</suppress>
 
-  <suppress until="2021-09-25">
+  <suppress until="2021-10-25">
     <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
       (any version), see https://pivotal.io/security/cve-2018-1258
       False positive confirmed.
@@ -20,7 +20,7 @@
     <cve>CVE-2018-1258</cve>
   </suppress>
 
-  <suppress until="2021-09-25">
+  <suppress until="2021-10-25">
    <notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
       library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
      Last control version: 1.5
@@ -31,7 +31,7 @@
     <cve>CVE-2020-29245</cve>
   </suppress>
 
-  <suppress until="2021-09-25">
+  <suppress until="2021-10-25">
     <notes>
       <![CDATA[
         Required dependencies with no current fixes


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1993 (https://tools.hmcts.net/jira/browse/CCD-1993)


### Change description ###
Updated CVE suppression dates in suppressions.xml to 25/10/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
