### PR TITLE
CCD-2114: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,8 +310,8 @@ dependencies {
 
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.0'
   compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.0'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.50'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.50'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.54'
 
   runtime group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -42,11 +42,6 @@
   </suppress>
 
   <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-
-  <suppress until="2021-11-25">
     <notes>Suppress CVEs affecting netty temporarily until they can be addressed</notes>
     <cve>CVE-2021-37136</cve>
     <cve>CVE-2021-37137</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2114 (https://tools.hmcts.net/jira/browse/CCD-2114)


### Change description ###
- Updated dependencies section of build.gradle.  Changed version of tomcat-embed-core and tomcat-embed-websocket to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
