### PR TITLE
CCD-2139: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
 }
 
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 ext['spring-security.version'] = '5.4.5'
 
 allprojects {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,9 +47,4 @@
     <cve>CVE-2021-37137</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,7 +36,7 @@
       <![CDATA[
         Required dependencies with no current fixes
         Last control version: 5.16.2
-    ]]>
+      ]]>
     </notes>
     <cve>CVE-2015-5182</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2139 (https://tools.hmcts.net/jira/browse/CCD-2139)


### Change description ###
- Updated build.gradle.  Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
