### PR TITLE
CCD-2118: Address CVE-2021-37136 and CVE-2021-37137 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,16 +275,16 @@ dependencies {
 
   implementation (group: 'org.springframework.security', name:'spring-security-crypto', 'version':'5.4.5') //For CVE-2021-22112
 
-  implementation group: 'io.netty', name:'netty-buffer', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-codec', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-codec-http', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-common', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-handler', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-resolver', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-transport', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-transport-native-epoll', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-transport-native-kqueue', version:'4.1.61.Final' //For CVE-2021-21295
-  implementation group: 'io.netty', name:'netty-transport-native-unix-common', version:'4.1.61.Final' //For CVE-2021-21295
+  implementation group: 'io.netty', name:'netty-buffer', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-codec', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-codec-http', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-common', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-handler', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-resolver', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-transport', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-transport-native-epoll', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-transport-native-kqueue', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  implementation group: 'io.netty', name:'netty-transport-native-unix-common', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
 
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1' // CVE-2021-28170
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,4 +46,10 @@
     <cve>CVE-2021-42340</cve>
   </suppress>
 
+  <suppress until="2021-11-25">
+    <notes>Suppress CVEs affecting netty temporarily until they can be addresses</notes>
+    <cve>CVE-2021-37136</cve>
+    <cve>CVE-2021-37137</cve>
+  </suppress>
+
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,10 +41,4 @@
     <cve>CVE-2015-5182</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVEs affecting netty temporarily until they can be addressed</notes>
-    <cve>CVE-2021-37136</cve>
-    <cve>CVE-2021-37137</cve>
-  </suppress>
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,7 +47,7 @@
   </suppress>
 
   <suppress until="2021-11-25">
-    <notes>Suppress CVEs affecting netty temporarily until they can be addresses</notes>
+    <notes>Suppress CVEs affecting netty temporarily until they can be addressed</notes>
     <cve>CVE-2021-37136</cve>
     <cve>CVE-2021-37137</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2118 (https://tools.hmcts.net/jira/browse/CCD-2118)


### Change description ###
- Updated build.gradle.  Set version of netty components to 4.1.68.Final to address CVE-2021-37136 and CVE-2021-37137.
- Removed temporary suppression of CVE-2021-37136 and CVE-2021-37137 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
