### PR TITLE
CCD-2107: Update CVE suppression dates

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,7 +11,7 @@
     <cve>CVE-2020-23171</cve>
 	</suppress>
 
-  <suppress until="2021-11-25">
+  <suppress until="2021-12-25">
     <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
       (any version), see https://pivotal.io/security/cve-2018-1258
       False positive confirmed.
@@ -20,7 +20,7 @@
     <cve>CVE-2018-1258</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
+  <suppress until="2021-12-25">
    <notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
       library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
      Last control version: 1.5
@@ -31,7 +31,7 @@
     <cve>CVE-2020-29245</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
+  <suppress until="2021-12-25">
     <notes>
       <![CDATA[
         Required dependencies with no current fixes


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2107 (https://tools.hmcts.net/jira/browse/CCD-2107)


### Change description ###
Updated CVE suppression dates in suppressions.xml to 25/12/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
