### PR TITLE
CCD-2312: Temporarily disable Fortify Scan in nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,10 +12,11 @@ def product = "ccd"
 def component = "message-publisher"
 
 withNightlyPipeline(type, product, component) {
-  enableFortifyScan()
-  after('fortify-scan') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
-  }
+  // Temporarily disable fortify scan stage until fortify access re-enabled
+  //enableFortifyScan()
+  //after('fortify-scan') {
+  //  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
+  //}
 }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2312 (https://tools.hmcts.net/jira/browse/CCD-2312)


### Change description ###
Temporarily disable the Fortify Scan stage in the nightly build until Fortify access is re-enabled.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
