### PR TITLE
CVE fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,16 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.4.4'
-  id 'org.owasp.dependencycheck' version '6.0.3'
+  id 'org.owasp.dependencycheck' version '6.5.3'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.0'
   id 'uk.gov.hmcts.java' version '0.11.0'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
 }
 
-ext['spring-framework.version'] = '5.3.12'
+ext['spring-framework.version'] = '5.3.15'
 ext['spring-security.version'] = '5.4.5'
-ext['log4j2.version'] = '2.17.0'
+ext['log4j2.version'] = '2.17.1'
 
 allprojects {
   sourceCompatibility = '11'
@@ -246,7 +246,8 @@ def versions = [
   junitVintageVersion : '5.7.0',
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '3.0.0',
-  testcontainers  : '1.15.1'
+  testcontainers  : '1.15.1',
+  netty           : '4.1.74.Final'
 ]
 
 ext.libraries = [
@@ -274,21 +275,24 @@ dependencies {
     exclude group: 'org.simpleframework', module: 'simple-xml' //CVE-2017-1000190
     exclude group: 'org.nanohttpd', module: 'nanohttpd' //CVE-2020-13697
   }
-
-  implementation (group: 'org.springframework.security', name:'spring-security-crypto', 'version':'5.4.5') //For CVE-2021-22112
-
-  implementation group: 'io.netty', name:'netty-buffer', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-codec', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-codec-http', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-common', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-handler', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-resolver', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-transport', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-transport-native-epoll', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-transport-native-kqueue', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
-  implementation group: 'io.netty', name:'netty-transport-native-unix-common', version:'4.1.68.Final' //For CVE-2021-37136 and CVE-2021-37137
+  //CVE-2021-22119
+  implementation (group: 'org.springframework.security', name:'spring-security-crypto', 'version':'5.4.7')
+  // CVE-2021-43797
+  implementation group: 'io.netty', name:'netty-buffer', version: versions.netty
+  implementation group: 'io.netty', name:'netty-codec', version: versions.netty
+  implementation group: 'io.netty', name:'netty-codec-http', version: versions.netty
+  implementation group: 'io.netty', name:'netty-common', version: versions.netty
+  implementation group: 'io.netty', name:'netty-handler', version: versions.netty
+  implementation group: 'io.netty', name:'netty-resolver', version: versions.netty
+  implementation group: 'io.netty', name:'netty-transport', version: versions.netty
+  implementation group: 'io.netty', name:'netty-transport-native-epoll', version: versions.netty
+  implementation group: 'io.netty', name:'netty-transport-native-kqueue', version: versions.netty
+  implementation group: 'io.netty', name:'netty-transport-native-unix-common', version: versions.netty
 
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1' // CVE-2021-28170
+  // CVE-2021-42550
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
 
   implementation group: 'io.hawt', name: 'hawtio-springboot', version: '2.12.0'
 
@@ -309,8 +313,8 @@ dependencies {
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.54'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.58'
 
   runtime group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -40,13 +40,5 @@
     </notes>
     <cve>CVE-2015-5182</cve>
   </suppress>
-  
-  <suppress until="2022-02-25">
-    		<cve>CVE-2021-22060</cve>
-		    <cve>CVE-2022-23181</cve>
-		    <cve>CVE-2021-42550</cve>
-        <cve>CVE-2021-43797</cve>
-		    <cve>CVE-2021-44832</cve>
-  </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-2646
https://tools.hmcts.net/jira/browse/CCD-2639
https://tools.hmcts.net/jira/browse/CCD-2626
https://tools.hmcts.net/jira/browse/CCD-2613
https://tools.hmcts.net/jira/browse/CCD-2587

### Change description ###
Fixing:
- CVE-2021-22060 spring framework upgrade
- CVE-2022-23181 tomcat upgrade
- CVE-2021-42550 ch.qos.logback
- CVE-2021-44832 log4j upgrade
- CVE-2021-43797 netty upgrade
- CVE-2021-22119 spring security upgrade


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```