### PR TITLE
CVE suppression for spring plugin core/metadata dependency check issue

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-  <suppress until="2022-04-25">
+  <suppress until="2022-05-25">
     <notes>
 			Declared as False positive on library com.nimbusds:lang-tag #3594
 			https://github.com/jeremylong/DependencyCheck/issues/3594
@@ -11,7 +11,7 @@
     <cve>CVE-2020-23171</cve>
 	</suppress>
 
-  <suppress until="2022-04-25">
+  <suppress until="2022-05-25">
     <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
       (any version), see https://pivotal.io/security/cve-2018-1258
       False positive confirmed.
@@ -20,7 +20,7 @@
     <cve>CVE-2018-1258</cve>
   </suppress>
 
-  <suppress until="2022-04-25">
+  <suppress until="2022-05-25">
    <notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
       library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
      Last control version: 1.5
@@ -31,7 +31,7 @@
     <cve>CVE-2020-29245</cve>
   </suppress>
 
-  <suppress until="2022-04-25">
+  <suppress until="2022-05-25">
     <notes>
       <![CDATA[
         Required dependencies with no current fixes
@@ -41,14 +41,46 @@
     <cve>CVE-2015-5182</cve>
   </suppress>
   <!-- Suppress until fixed -->
-  <suppress until="2022-04-25">
+  <suppress until="2022-05-25">
     <cve>CVE-2022-21724</cve>
   </suppress>
 
-  <suppress until="2022-04-25">
+  <suppress until="2022-05-25">
     <cve>CVE-2013-4152</cve>
     <cve>CVE-2014-0054</cve>
     <cve>CVE-2013-7315</cve>
+  </suppress>
+
+  <suppress until="2022-05-25">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
+
+  <suppress until="2022-05-25">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2022-22965</cve>
+  </suppress>
+
+  <suppress until="2022-05-25">
+    <notes><![CDATA[
+   file name: spring-plugin-metadata-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-metadata@.*$</packageUrl>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
+
+  <suppress until="2022-05-25">
+    <notes><![CDATA[
+   file name: spring-plugin-metadata-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-metadata@.*$</packageUrl>
+    <cve>CVE-2022-22965</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
### Change description ###
There are dependency check issues with spring-plugin-metadata and spring-plugin-core version, pipeline is failing.This is a suppression change. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
