### PR TITLE
CVE-2022-24823 : ccd-message-publisher fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,7 @@ def versions = [
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.1',
-  netty           : '4.1.74.Final'
+  netty           : '4.1.77.Final'
 ]
 
 ext.libraries = [

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -101,8 +101,4 @@
     <cve>CVE-2022-22968</cve>
   </suppress>
 
-  <suppress until="2022-06-25">
-    <cve>CVE-2022-24823</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3183

Upgrading nettty version to 4.1.77.Final.
Netty is an open-source, asynchronous event-driven network application framework. The package `io.netty:netty-codec-http` prior to version 4.1.77.Final contains an insufficient fix for CVE-2021-21290. 
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
