### PR TITLE
CVE-2022-29885: ccd-message-publisher fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,8 +317,8 @@ dependencies {
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.58'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
+  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
 
   runtime group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -80,20 +80,6 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-metadata@.*$</packageUrl>
     <cve>CVE-2022-22968</cve>
   </suppress>
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
 
   <suppress until="2022-06-25">
     <notes>False-positive. See CCD-3104</notes>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3272

Upgrading tomcat version to 9.0.63.
The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
