### PR TITLE
CVE-2022-22976 ccd-message-publisher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 ext['spring-framework.version'] = '5.3.20'
-ext['spring-security.version'] = '5.4.5'
+ext['spring-security.version'] = '5.7.1'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
 
@@ -280,7 +280,7 @@ dependencies {
     exclude group: 'org.nanohttpd', module: 'nanohttpd' //CVE-2020-13697
   }
   //CVE-2021-22119
-  implementation (group: 'org.springframework.security', name:'spring-security-crypto', 'version':'5.4.7')
+  implementation (group: 'org.springframework.security', name:'spring-security-crypto', 'version':'5.7.1')
   // CVE-2021-43797
   implementation group: 'io.netty', name:'netty-buffer', version: versions.netty
   implementation group: 'io.netty', name:'netty-codec', version: versions.netty

--- a/charts/ccd-message-publisher/Chart.yaml
+++ b/charts/ccd-message-publisher/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 description: A Helm chart for the HMCTS CCD Message Publisher
 name: ccd-message-publisher
 home: https://github.com/hmcts/ccd-message-publisher
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: HMCTS CCD Dev Team
 dependencies:
   - name: java
     version: 3.7.3
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 0.3.1
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: servicebus.enabled

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -93,11 +93,4 @@
     <cve>CVE-2022-22970</cve>
   </suppress>
 
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-security-rsa-1.0.9.RELEASE.jar
-   ]]></notes>
-    <cve>CVE-2022-22976</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3336

Spring Security versions 5.5.x prior to 5.5.7, 5.6.x prior to 5.6.4, and earlier unsupported versions contain an integer overflow vulnerability. When using the BCrypt class with the maximum work factor (31), the encoder does not perform any salt rounds, due to an integer overflow error. The default settings are not affected by this CVE.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
