### PR TITLE
CCD-3448: CVE-2022-33915 ccd-message-publisher

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,12 +8,14 @@
       CVE-2018-11040    refer https://tools.hmcts.net/jira/browse/CCD-3407
       CVE-2018-1257     refer https://tools.hmcts.net/jira/browse/CCD-3408
       CVE-2020-5421     refer https://tools.hmcts.net/jira/browse/CCD-3409
+      CVE-2022-33915    refer https://tools.hmcts.net/jira/browse/CCD-3448
     </notes>
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2018-11039</cve>
     <cve>CVE-2018-11040</cve>
     <cve>CVE-2018-1257</cve>
     <cve>CVE-2020-5421</cve>
+    <cve>CVE-2022-33915</cve>
   </suppress>
   <!--End of false positives section -->
 
@@ -30,7 +32,6 @@
       CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3359
       CVE-2022-22950  refer https://tools.hmcts.net/jira/browse/CCD-3400
       CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3430
-      CVE-2022-33915  refer https://tools.hmcts.net/jira/browse/CCD-3448
     </notes>
     <cve>CVE-2013-4152</cve>
     <cve>CVE-2014-0054</cve>
@@ -42,7 +43,6 @@
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-22950</cve>
     <cve>CVE-2022-34305</cve>
-    <cve>CVE-2022-33915</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-3448

### Change description ###
False positive.   CVE-2022-33915 (cpe;2.3;a;apache;log4j) only impacts AWS Log4j hotpatch , and not general Log4j build.   See Jira ticket.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```