### PR TITLE
CCD-3605: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,7 @@ dependencies {
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
 
-  runtime group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
+  runtime group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'
 
   aatImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.14.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,7 +37,6 @@
       CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3359
       CVE-2022-22950  refer https://tools.hmcts.net/jira/browse/CCD-3400
       CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
-      CVE-2022-31197  refer https://tools.hmcts.net/jira/browse/CCD-3605
     </notes>
     <cve>CVE-2022-22965</cve>
     <cve>CVE-2022-22968</cve>
@@ -46,7 +45,6 @@
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-22950</cve>
     <cve>CVE-2022-31569</cve>
-    <cve>CVE-2022-31197</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3605

### Change description ###

CCD-3605: Upgraded org.postgresql to 42.4.1 and removed temporary suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
