### PR TITLE
CCD-3648: Fix preview deploy issues

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -58,7 +58,7 @@ withPipeline(type, product, component) {
     if (env.BRANCH_NAME.startsWith("PR") || env.BRANCH_NAME == 'master') {
       environmentOfDependencies = "aat"
     } else{
-      env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
+      env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
     }
   }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -13,7 +13,7 @@ def prsToUseAat             = "PR-1193,PR-1219,PR-1248,PR-1311" // Set this valu
 
 // vars needed for functional tests
 // Assume a feature build branched off 'develop', with dependencies develop-to-develop.
-env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
+env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
 
 // Env variables needed for BEFTA.
 env.CCD_API_GATEWAY_OAUTH2_CLIENT_ID = "ccd_gateway"


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3648 (https://tools.hmcts.net/jira/browse/CCD-3648)


### Change description ###
Changed DEFINITION_STORE_URL_BASE URL value used for preview in Jenkinsfile_CNP to use https instead of http.

Although this component doesn't currently appear to use DEFINITION_STORE_URL_BASE for any tests in preview it's being correcting in case it is needed in the future.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
