### PR TITLE
CCD-4047-Fix-CVE-2022-41946

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,7 +317,7 @@ dependencies {
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcatVersion
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcatVersion
 
-  runtime group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
+  runtime group: 'org.postgresql', name: 'postgresql', version: '42.5.1'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'
 
   aatImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.14.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
+    <notes>False Positives
+      CVE-2016-1000027  refer https://tools.hmcts.net/jira/browse/CCD-3104
+    </notes>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
+  <suppress>
     <notes>Temporary Suppression
-        CVE-2022-41946 refer [Ticket]
-        CVE-2016-4432 refer https://tools.hmcts.net/jira/browse/CCD-4056
         CVE-2016-3094 refer https://tools.hmcts.net/jira/browse/CCD-4056
-        CVE-2016-4432 refer [Ticket]
-        CVE-2016-3094 refer [Ticket]
         CVE-2021-37533 refer [Ticket]</notes>
-    <cve>CVE-2022-41946</cve>
     <cve>CVE-2016-3094</cve>
     <cve>CVE-2021-37533</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4047

### Change description ###

Upgraded 'org.postgresql' to version: '42.5.1'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
