### PR TITLE
CCD-4056: Move CVE-2016-3094 to false positives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,7 +317,7 @@ dependencies {
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcatVersion
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcatVersion
 
-  runtime group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
+  runtime group: 'org.postgresql', name: 'postgresql', version: '42.5.1'
   runtime group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'
 
   aatImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.14.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,10 +12,8 @@
   <!--Please add all the temporary suppressions under the below section-->
   <suppress>
     <notes>Temporary Suppression
-      CVE-2022-41946 refer [Ticket]
-      CVE-2021-37533 refer [Ticket]
+      CVE-2021-37533 refer https://tools.hmcts.net/jira/browse/CCD-4086
     </notes>
-    <cve>CVE-2022-41946</cve>
     <cve>CVE-2021-37533</cve>
   </suppress>
   <!--End of temporary suppressions section -->

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+  <!--Please add all the false positives under the below section-->
+  <suppress>
+    <notes>False Positives
+      CVE-2016-3094 refer https://tools.hmcts.net/jira/browse/CCD-4056
+    </notes>
+    <cve>CVE-2016-3094</cve>
+  </suppress>
+  <!--End of false positives section -->
+
+  <!--Please add all the temporary suppressions under the below section-->
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-41946 refer [Ticket]
-        CVE-2016-4432 refer https://tools.hmcts.net/jira/browse/CCD-4056
-        CVE-2016-3094 refer https://tools.hmcts.net/jira/browse/CCD-4056
-        CVE-2016-4432 refer [Ticket]
-        CVE-2016-3094 refer [Ticket]
-        CVE-2021-37533 refer [Ticket]</notes>
+      CVE-2022-41946 refer [Ticket]
+      CVE-2021-37533 refer [Ticket]
+    </notes>
     <cve>CVE-2022-41946</cve>
-    <cve>CVE-2016-3094</cve>
     <cve>CVE-2021-37533</cve>
   </suppress>
+  <!--End of temporary suppressions section -->
+
 </suppressions>


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4056

### Change description ###
Moved CVE-2016-3094 to false positives.   Affected dependency is org.apache.qpid/qpid-client (not org.apache.qpid/qpid-jms-client).
Removed CVE-2016-4432 as no longer issue.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```