### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.1',
   netty           : '4.1.86.Final',
-  tomcatVersion   : '9.0.69'
+  tomcatVersion   : '9.0.73'
 ]
 
 ext.libraries = [
@@ -313,6 +313,7 @@ dependencies {
   implementation group: 'org.apache.activemq', name: 'activemq-broker', version: '5.16.1' // For CVE-2021-26117
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcatVersion
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcatVersion

--- a/charts/ccd-message-publisher/Chart.yaml
+++ b/charts/ccd-message-publisher/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 description: A Helm chart for the HMCTS CCD Message Publisher
 name: ccd-message-publisher
 home: https://github.com/hmcts/ccd-message-publisher
-version: 0.1.10
+version: 0.1.11
 maintainers:
   - name: HMCTS CCD Dev Team
 dependencies:
   - name: java
-    version: 4.0.12
+    version: 4.0.13
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 0.4.0

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,7 +7,10 @@
   </suppress>
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer [Ticket]</notes>
+        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
+        CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
+    </notes>
     <cve>CVE-2022-45688</cve>
+    <cve>CVE-2022-1471</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
