### PR TITLE
CCD-4739 : Fix CVE-2023-20863 (bumped versions of: gradle, springframework, springsecurity)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-  id 'org.springframework.boot' version '2.7.11'
+  id 'org.springframework.boot' version '2.4.4'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.0'
   id 'uk.gov.hmcts.java' version '0.12.43'

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,15 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-  id 'org.springframework.boot' version '2.4.4'
+  id 'org.springframework.boot' version '2.7.11'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.0'
   id 'uk.gov.hmcts.java' version '0.12.43'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
 }
 
-ext['spring-framework.version'] = '5.3.26'
-ext['spring-security.version'] = '5.6.9'
+ext['spring-framework.version'] = '5.3.27'
+ext['spring-security.version'] = '5.7.8'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '1.32'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,15 +3,13 @@
     <notes>Temporary Suppression
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-        CVE-2023-20863 refer [Ticket]
         CVE-2023-20873 refer [Ticket]
-    
         CVE-2023-28709 refer [Ticket]
         CVE-2023-20883 refer [Ticket]
-        CVE-2023-34411 refer [Ticket]</notes>
+        CVE-2023-34411 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-20863</cve>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-28709</cve>
     <cve>CVE-2023-20883</cve>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4739

### Change description ###

CCD-4739 : Fix CVE-2023-20863 (bumped versions of: gradle, springframework, springsecurity)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
