### PR TITLE
CCD-4737 : Fix CVE-2023-28709 (bumped version of Tomcat)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.1',
   netty           : '4.1.86.Final',
-  tomcatVersion   : '9.0.73'
+  tomcatVersion   : '9.0.75'
 ]
 
 ext.libraries = [

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -5,17 +5,15 @@
         CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
         CVE-2023-20863 refer [Ticket]
         CVE-2023-20873 refer [Ticket]
-    
-        CVE-2023-28709 refer [Ticket]
         CVE-2023-20883 refer [Ticket]
         CVE-2023-34411 refer [Ticket]
         CVE-2023-35116 refer [Ticket]
-        CVE-2023-2976 refer [Ticket]</notes>
+        CVE-2023-2976 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-20863</cve>
     <cve>CVE-2023-20873</cve>
-    <cve>CVE-2023-28709</cve>
     <cve>CVE-2023-20883</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-2976</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4737

### Change description ###

CCD-4737 : Fix CVE-2023-28709 (bumped version of Tomcat)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
