### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ repositories {
 def versions = [
   junit           : '5.7.0',
   junitPlatform   : '1.7.0',
-  reformLogging   : '5.1.9',
+  reformLogging   : '6.0.1',
   junitVintageVersion : '5.7.0',
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '3.0.0',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.