### PR TITLE
CCD-5066 : Fix broken master pipeline due to CVE clash between DBs

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -35,8 +35,8 @@ jobs:
         continue-on-error: true
       - name: Run suppressCves
         run: ./gradlew suppressCves
-      - name: Run cleanSuppressions
-        run: ./gradlew cleanSuppressions
+      #- name: Run cleanSuppressions
+      #  run: ./gradlew cleanSuppressions
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,7 +21,7 @@
         CVE-2023-45960 refer [Ticket]
         CVE-2023-46604 refer [Ticket]
         CVE-2023-36052 refer [Ticket]
-        CVE-2023-45960 refer CVE removed via plugin but still being reported (to be removed)
+        CVE-2023-45960 [this needs to be removed as its not a vulnerability in the central db]
     </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-20873</cve>
@@ -40,5 +40,6 @@
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-46604</cve>
     <cve>CVE-2023-36052</cve>
+    <cve>CVE-2023-45960</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-5066

### Change description ###

Commented out './gradlew cleanSuppressions'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
