### PR TITLE
CCD-4969: bumped spring-security.version to v5.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 ext['spring-framework.version'] = '5.3.27'
-ext['spring-security.version'] = '5.7.8'
+ext['spring-security.version'] = '5.7.10'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,7 +7,6 @@
         CVE-2023-35116 refer [Ticket]
         CVE-2023-2976 refer [Ticket]
         CVE-2023-34462 refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
         CVE-2023-34040 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-4586 refer [Ticket]
@@ -18,11 +17,9 @@
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-5072 refer [Ticket]
-        CVE-2023-45960 refer [Ticket]
         CVE-2023-46604 refer [Ticket]
         CVE-2023-36052 refer [Ticket]
         CVE-2023-45960 [this needs to be removed as its not a vulnerability in the central db]
-    
         CVE-2023-33202 refer [Ticket]
         CVE-2022-41678 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
@@ -33,7 +30,6 @@
     <cve>CVE-2023-20883</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-34462</cve>
-    <cve>CVE-2023-34034</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-4586</cve>
     <cve>CVE-2023-36414</cve>
@@ -45,7 +41,6 @@
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-46604</cve>
     <cve>CVE-2023-36052</cve>
-    <cve>CVE-2023-45960</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2022-41678</cve>
     <cve>CVE-2023-34055</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

CCD-4969

### Change description ###

bumped spring-security.version to v5.7.10

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
