### PR TITLE
Fix CVE-2023-35116 : bump jackson.version to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 ext['spring-framework.version'] = '5.3.27'
 ext['spring-security.version'] = '5.7.10'
 ext['log4j2.version'] = '2.17.1'
-ext['jackson.version'] = '2.14.1'
+ext['jackson.version'] = '2.16.0'
 ext['snakeyaml.version'] = '2.0'
 
 configurations {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
     <notes>Temporary Suppression
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2023-20873 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
         CVE-2023-2976 refer [Ticket]
         CVE-2023-34462 refer [Ticket]
         CVE-2023-34040 refer [Ticket]
@@ -27,7 +26,6 @@
     </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-20873</cve>
-    <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-34462</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-4586</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5160

Fix CVE-2023-35116 : bump jackson.version to 2.16.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
