### PR TITLE
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ def versions = [
   springfoxSwagger   : '3.0.0',
   testcontainers     : '1.18.3',
   netty              : '4.1.86.Final',
-  tomcatVersion      : '9.0.75'
+  tomcatVersion      : '9.0.82'
 ]
 
 ext.libraries = [

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,52 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-        CVE-2023-20873 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
-        CVE-2023-2976 refer [Ticket]
-        CVE-2023-34462 refer [Ticket]
-        CVE-2023-34040 refer [Ticket]
-        CVE-2023-41080 refer [Ticket]
-        CVE-2023-4586 refer [Ticket]
-        CVE-2023-36414 refer [Ticket]
-        CVE-2023-36415 refer [Ticket]
-        CVE-2023-42794 refer [Ticket]
-        CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2023-5072 refer [Ticket]
         CVE-2023-46604 refer [Ticket]
         CVE-2023-36052 refer [Ticket]
+        CVE-2023-36414 refer [Ticket]
+        CVE-2023-36415 refer [Ticket]
+        CVE-2023-35116 refer [Ticket]
+        CVE-2022-45688 refer [Ticket]
+        CVE-2023-5072 refer [Ticket]
         CVE-2023-6378 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-34055 refer https://tools.hmcts.net/jira/browse/CCD-5135
-        CVE-2022-41678 refer [Ticket]
+        CVE-2023-44487 refer [Ticket]
+        CVE-2023-34462 refer [Ticket]
         CVE-2023-34042 refer [Ticket]
-        CVE-2023-34055 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
-    </notes>
-    <cve>CVE-2022-45688</cve>
-    <cve>CVE-2023-20873</cve>
-    <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-34462</cve>
-    <cve>CVE-2023-41080</cve>
-    <cve>CVE-2023-4586</cve>
-    <cve>CVE-2023-36414</cve>
-    <cve>CVE-2023-36415</cve>
-    <cve>CVE-2023-42794</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-5072</cve>
+        CVE-2023-46589 refer [Ticket]</notes>
     <cve>CVE-2023-46604</cve>
     <cve>CVE-2023-36052</cve>
-    <cve>CVE-2023-45960</cve>
-    <cve>CVE-2022-41678</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-46589</cve>
+    <cve>CVE-2023-36414</cve>
+    <cve>CVE-2023-36415</cve>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-6378</cve>
+    <cve>CVE-2023-44487</cve>
+    <cve>CVE-2023-34462</cve>
     <cve>CVE-2023-34042</cve>
+    <cve>CVE-2023-46589</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4972
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
