### PR TITLE
CCD-5159:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,9 @@ dependencies {
   implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: versions.netty
 
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1' // CVE-2021-28170
+  // CVE-2021-42550
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 

--- a/build.gradle
+++ b/build.gradle
@@ -330,8 +330,10 @@ dependencies {
 
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1' // CVE-2021-28170
   // CVE-2021-42550
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.13'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.13'
+
+  implementation group: 'io.hawt', name: 'hawtio-springboot', version: '2.12.0'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 

--- a/build.gradle
+++ b/build.gradle
@@ -330,10 +330,10 @@ dependencies {
 
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1' // CVE-2021-28170
   // CVE-2021-42550
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
-
-  implementation group: 'io.hawt', name: 'hawtio-springboot', version: '2.12.0'
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
+  // to add LoggingEventAware
+  implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 

--- a/build.gradle
+++ b/build.gradle
@@ -329,11 +329,6 @@ dependencies {
   implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: versions.netty
 
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1' // CVE-2021-28170
-  // CVE-2021-42550
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
-  // to add LoggingEventAware
-  implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16'
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,7 +16,6 @@
         CVE-2022-45688 refer [Ticket]
         CVE-2023-5072 refer [Ticket]
         CVE-2023-1370 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
         CVE-2023-34042 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2024-1597 refer [Ticket]
@@ -30,7 +29,6 @@
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-1370</cve>
-    <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-44487</cve>
     <cve>CVE-2024-1597</cve>
     <cve>CVE-2023-46589</cve>


### PR DESCRIPTION
Fix CVE-2023-6378, upgrading logback-core and logback-classic from 1.2.10 to 1.5.6. Adding slf4j-api for LoggingEventAware

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5159


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
