### PR TITLE
CCD-6110:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,7 +322,10 @@ dependencies {
   implementation(group: 'com.microsoft.azure', name: 'azure-servicebus-jms-spring-boot-starter', version: '2.3.5') {
     exclude group: 'org.simpleframework', module: 'simple-xml' //CVE-2017-1000190
     exclude group: 'org.nanohttpd', module: 'nanohttpd' //CVE-2020-13697
+    exclude group: 'com.azure', module: 'azure-identity'
   }
+
+  implementation group: 'com.azure', name: 'azure-identity', version: '1.15.2'
 
   implementation group: 'io.netty', name: 'netty-buffer', version: versions.netty
   implementation group: 'io.netty', name: 'netty-codec', version: versions.netty

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,13 +2,9 @@
   <!--Please add all the false positives under the below section-->
   <suppress>
     <notes>False Positives
-        CVE-2023-36414 refer [https://nvd.nist.gov/vuln/detail/CVE-2023-36414]
         CVE-2023-36415 refer [https://nvd.nist.gov/vuln/detail/CVE-2023-36415]
-        CVE-2024-35255 refer [https://nvd.nist.gov/vuln/detail/CVE-2024-35255]
     </notes>
-    <cve>CVE-2023-36414</cve>
     <cve>CVE-2023-36415</cve>
-    <cve>CVE-2024-35255</cve>
   </suppress>
   <suppress>
     <notes>Temporary Suppression


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-6110


### Change description ###
Fix CVE-2023-36414 and CVE-2024-35255, upgraded azure-identity from 1.1.2 to 1.15.2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
