### PR TITLE
CME-765 adjust timeout values

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ spring:
     servicebus:
       connection-string: ${SERVICE_BUS_CONNECTION_STRING}
       pricing-tier: ${SERVICE_BUS_PRICING_TIER:standard}
-      idle-timeout: ${SERVICE_BUS_IDLE_TIMEOUT:1800000}
+      idle-timeout: ${SERVICE_BUS_IDLE_TIMEOUT:240000} # 4 minutes
   jpa:
     database: postgresql
   datasource:
@@ -38,9 +38,9 @@ spring:
     hikari:
       minimumIdle: ${MESSAGE_PUBLISHER_DB_MIN_IDLE:2}
       maximumPoolSize: ${MESSAGE_PUBLISHER_DB_MAX_POOL_SIZE:8}
-      idleTimeout: ${MESSAGE_PUBLISHER_DB_IDLE_TIMEOUT:300000}
-      maxLifetime: ${MESSAGE_PUBLISHER_DB_MAX_LIFTIME:7200000}
-      connectionTimeout: ${MESSAGE_PUBLISHER_DB_CONNECTION_TIMEOUT:40000}
+      idleTimeout: ${MESSAGE_PUBLISHER_DB_IDLE_TIMEOUT:300000} # 5 minutes
+      maxLifetime: ${MESSAGE_PUBLISHER_DB_MAX_LIFTIME:1740000} # 29 minutes
+      connectionTimeout: ${MESSAGE_PUBLISHER_DB_CONNECTION_TIMEOUT:40000} # 40 seconds
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration
   cloud:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ spring:
       minimumIdle: ${MESSAGE_PUBLISHER_DB_MIN_IDLE:2}
       maximumPoolSize: ${MESSAGE_PUBLISHER_DB_MAX_POOL_SIZE:8}
       idleTimeout: ${MESSAGE_PUBLISHER_DB_IDLE_TIMEOUT:300000} # 5 minutes
-      maxLifetime: ${MESSAGE_PUBLISHER_DB_MAX_LIFTIME:1740000} # 29 minutes
+      maxLifetime: ${MESSAGE_PUBLISHER_DB_MAX_LIFETIME:1740000} # 29 minutes
       connectionTimeout: ${MESSAGE_PUBLISHER_DB_CONNECTION_TIMEOUT:40000} # 40 seconds
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CME-765


### Change description ###
* reduce db max lifetime value to be less than default azure network timeout
* reduce jms idle-timeout to 4min so it does not timeout on broker implied 5 minutes timeout.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
